### PR TITLE
chore: add CI/CD support for add-on storybook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 node_modules
 lib
 scss
-storybook-static
+static
 
 # Logs
 *.log

--- a/.prettierignore
+++ b/.prettierignore
@@ -2,3 +2,4 @@ node_modules
 lib
 scss
 storybook-static
+package.json

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,9 @@ language: node_js
 node_js:
   - '8'
 
+notifications:
+  email: false
+
 cache:
   yarn: true
   directories:
@@ -15,5 +18,16 @@ before_install:
 script:
   - yarn ci-check
 
-notifications:
-  email: false
+before_deploy:
+  - yarn build-storybook
+
+deploy:
+  skip_cleanup: true
+  provider: cloudfoundry
+  username: apikey
+  password: $CLOUD_API_KEY
+  api: https://api.ng.bluemix.net
+  organization: carbon-design-system
+  space: production
+  on:
+    branch: master

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,9 @@
+# Contributing
+
+## Deployment
+
+If you're a core Carbon contributor, you are able to deploy the storybook for this add-on by doing the following:
+
+```bash
+cf push -f deploy/manifest.yml
+```

--- a/deploy/Staticfile
+++ b/deploy/Staticfile
@@ -1,0 +1,1 @@
+root: static

--- a/deploy/manifest.yml
+++ b/deploy/manifest.yml
@@ -1,0 +1,8 @@
+---
+applications:
+- name: carbon-addon-cloud-storybook
+  memory: 64M
+  buildpack: https://github.com/cloudfoundry/staticfile-buildpack.git
+  routes:
+  - route: carbon-addon-cloud-storybook.mybluemix.net
+  - route: addon-cloud.carbondesignsystem.com

--- a/package.json
+++ b/package.json
@@ -2,14 +2,12 @@
   "name": "carbon-addons-cloud",
   "version": "0.1.0",
   "main": "lib/index.js",
-  "files": [
-    "lib"
-  ],
+  "files": ["lib"],
   "scripts": {
     "build": "yarn clean && yarn build:js && yarn build:scss",
     "build:js": "babel -q -d lib --ignore \"__tests__,__mocks__\" src",
     "build:scss": "cpx src/**/*.scss scss",
-    "build:storybook": "build-storybook",
+    "build:storybook": "build-storybook -o deploy/static",
     "ci-check": "yarn test --runInBand",
     "clean": "rimraf lib scss",
     "commitmsg": "validate-commit-msg",
@@ -61,12 +59,7 @@
     "whatwg-fetch": "^2.0.3"
   },
   "babel": {
-    "presets": [
-      "env",
-      "stage-1",
-      "react",
-      "flow"
-    ]
+    "presets": ["env", "stage-1", "react", "flow"]
   },
   "prettier": {
     "jsxBracketSameLine": true,
@@ -75,14 +68,8 @@
     "trailingComma": "es5"
   },
   "lint-staged": {
-    "*.js": [
-      "prettier",
-      "git add"
-    ],
-    "*.{css,scss}": [
-      "prettier",
-      "git add"
-    ]
+    "*.js": ["prettier", "git add"],
+    "*.{css,scss}": ["prettier", "git add"]
   },
   "config": {
     "validate-commit-msg": {
@@ -104,9 +91,7 @@
     }
   },
   "jest": {
-    "collectCoverageFrom": [
-      "components/**/*.js"
-    ],
+    "collectCoverageFrom": ["components/**/*.js"],
     "setupFiles": [
       "<rootDir>/config/polyfills.js",
       "<rootDir>/config/jest/setup.js"
@@ -121,19 +106,9 @@
       "^.+\\.s?css$": "<rootDir>/config/jest/cssTransform.js",
       "^(?!.*\\.(js|jsx|css|json)$)": "<rootDir>/config/jest/fileTransform.js"
     },
-    "testPathIgnorePatterns": [
-      "/config/",
-      "/lib/"
-    ],
-    "transformIgnorePatterns": [
-      "[/\\\\]node_modules[/\\\\].+\\.(js|jsx)$"
-    ],
-    "moduleFileExtensions": [
-      "js",
-      "json"
-    ],
-    "snapshotSerializers": [
-      "enzyme-to-json/serializer"
-    ]
+    "testPathIgnorePatterns": ["/config/", "/lib/"],
+    "transformIgnorePatterns": ["[/\\\\]node_modules[/\\\\].+\\.(js|jsx)$"],
+    "moduleFileExtensions": ["js", "json"],
+    "snapshotSerializers": ["enzyme-to-json/serializer"]
   }
 }


### PR DESCRIPTION
Add CD support for the storybook for this add-on

#### Changelog

**New**

- `deploy` directory with a `manifest.yml` and `Staticfile`
- Simple `CONTRIBUTING.md` file with deploy instructions

**Changed**

- `.gitignore` now ignores the `static` path in `deploy
- `.prettierignore` now ignores `package.json`
- `package.json` updated `build:storybook` script to specify output directory

**Removed**
