### PR TITLE
fix: add 'index.js' entrypoint

### DIFF
--- a/src/components/CloudHeader/__tests__/CloudHeader-test.js
+++ b/src/components/CloudHeader/__tests__/CloudHeader-test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import CloudHeader from '../CloudHeader';
+import CloudHeader from '../../CloudHeader';
 import { shallow, mount } from 'enzyme';
 
 describe('CloudHeader', () => {

--- a/src/components/CloudHeader/__tests__/CloudHeaderList-test.js
+++ b/src/components/CloudHeader/__tests__/CloudHeaderList-test.js
@@ -1,6 +1,6 @@
 import React from 'react';
-import CloudHeaderList from '../CloudHeaderList';
-import CloudHeaderListItem from '../CloudHeaderListItem';
+import { CloudHeaderList } from '../../CloudHeader';
+import { CloudHeaderListItem } from '../../CloudHeader';
 import { shallow, mount } from 'enzyme';
 
 describe('CloudHeaderList', () => {

--- a/src/components/CloudHeader/__tests__/CloudHeaderLogo-test.js
+++ b/src/components/CloudHeader/__tests__/CloudHeaderLogo-test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import CloudHeaderLogo from '../CloudHeaderLogo';
+import { CloudHeaderLogo } from '../../CloudHeader';
 import { shallow, mount } from 'enzyme';
 
 describe('CloudHeaderLogo', () => {

--- a/src/components/CloudHeader/__tests__/CloudHeaderMenu-test.js
+++ b/src/components/CloudHeader/__tests__/CloudHeaderMenu-test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import CloudHeaderMenu from '../CloudHeaderMenu';
+import { CloudHeaderMenu } from '../../CloudHeader';
 import { shallow, mount } from 'enzyme';
 
 describe('CloudHeaderMenu', () => {

--- a/src/components/CloudHeader/__tests__/CloudHeaderWrapper-test.js
+++ b/src/components/CloudHeader/__tests__/CloudHeaderWrapper-test.js
@@ -1,6 +1,6 @@
 import React from 'react';
-import CloudHeaderWrapper from '../CloudHeaderWrapper';
-import CloudHeaderMenu from '../CloudHeaderMenu';
+import { CloudHeaderWrapper } from '../../CloudHeader';
+import { CloudHeaderMenu } from '../../CloudHeader';
 import { shallow, mount } from 'enzyme';
 
 describe('CloudHeaderWrapper', () => {

--- a/src/components/CloudHeader/index.js
+++ b/src/components/CloudHeader/index.js
@@ -1,0 +1,6 @@
+export default from './CloudHeader';
+export { default as CloudHeaderList } from './CloudHeaderList';
+export { default as CloudHeaderListItem } from './CloudHeaderListItem';
+export { default as CloudHeaderLogo } from './CloudHeaderLogo';
+export { default as CloudHeaderMenu } from './CloudHeaderMenu';
+export { default as CloudHeaderWrapper } from './CloudHeaderWrapper';

--- a/src/index.js
+++ b/src/index.js
@@ -1,8 +1,2 @@
-export {
-  CloudHeader,
-  CloudHeaderContainer,
-  CloudHeaderList,
-  CloudHeaderListItem,
-  CloudHeaderLogo,
-  CloudHeaderMenu,
-} from './components/CloudHeader';
+export * from './components/CloudHeader';
+export { default as CloudHeader } from './components/CloudHeader';


### PR DESCRIPTION
#### Changelog

**New**

- Add `index.js` to CloudHeader for exports

**Changed**

- Update `src/index.js`
- Update test paths

**Removed**
