### PR TITLE
fix: update paths to be from the package

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,10 +29,12 @@ The package also ships with the components Sass files as well. To use these, all
 
 ```scss
 // Default import path relative to `node_modules`
-@import 'node_modules/carbon-addons-cloud/scss/index.scss'
+@import 'carbon-addons-cloud/scss/index.scss'
 
 // If you're using webpack, you can use `~` to alias a node module
 @import '~/carbon-addons-cloud/scss/index.scss'
 ```
+
+In addition, make sure to include `node_modules` in your `node-sass` config. This will guarantee that all imports work as expected. You can find more about this option [here](https://github.com/sass/node-sass#includepaths).
 
 Component-specific Sass files are also included and can be imported in a similar fashion.

--- a/src/components/Card/_card.scss
+++ b/src/components/Card/_card.scss
@@ -1,14 +1,14 @@
-@import '../../../node_modules/carbon-components/scss/globals/scss/colors';
-@import '../../../node_modules/carbon-components/scss/globals/scss/helper-mixins';
-@import '../../../node_modules/carbon-components/scss/globals/scss/layout';
-@import '../../../node_modules/carbon-components/scss/globals/scss/layer';
-@import '../../../node_modules/carbon-components/scss/globals/scss/typography';
-@import '../../../node_modules/carbon-components/scss/globals/scss/import-once';
-@import '../../../node_modules/carbon-components/scss/globals/scss/css--reset';
-@import '../../../node_modules/carbon-components/scss/globals/scss/css--typography';
-@import '../../../node_modules/carbon-components/scss/components/overflow-menu/overflow-menu';
-@import '../../../node_modules/carbon-components/scss/components/button/button';
-@import '../../../node_modules/carbon-components/scss/components/link/link';
+@import 'carbon-components/scss/globals/scss/colors';
+@import 'carbon-components/scss/globals/scss/helper-mixins';
+@import 'carbon-components/scss/globals/scss/layout';
+@import 'carbon-components/scss/globals/scss/layer';
+@import 'carbon-components/scss/globals/scss/typography';
+@import 'carbon-components/scss/globals/scss/import-once';
+@import 'carbon-components/scss/globals/scss/css--reset';
+@import 'carbon-components/scss/globals/scss/css--typography';
+@import 'carbon-components/scss/components/overflow-menu/overflow-menu';
+@import 'carbon-components/scss/components/button/button';
+@import 'carbon-components/scss/components/link/link';
 @import 'mixins';
 
 @include exports('card') {

--- a/src/components/DetailPageHeader/_detail-page-header.scss
+++ b/src/components/DetailPageHeader/_detail-page-header.scss
@@ -1,15 +1,15 @@
-@import '../../../node_modules/carbon-components/scss/globals/scss/colors';
-@import '../../../node_modules/carbon-components/scss/globals/scss/vars';
-@import '../../../node_modules/carbon-components/scss/globals/scss/helper-mixins';
-@import '../../../node_modules/carbon-components/scss/globals/scss/layout';
-@import '../../../node_modules/carbon-components/scss/globals/scss/layer';
-@import '../../../node_modules/carbon-components/scss/globals/scss/typography';
-@import '../../../node_modules/carbon-components/scss/globals/scss/import-once';
-@import '../../../node_modules/carbon-components/scss/globals/scss/css--reset';
-@import '../../../node_modules/carbon-components/scss/globals/scss/css--typography';
-@import '../../../node_modules/carbon-components/scss/components/breadcrumb/breadcrumb';
-@import '../../../node_modules/carbon-components/scss/components/overflow-menu/overflow-menu';
-@import '../../../node_modules/carbon-components/scss/components/tabs/tabs';
+@import 'carbon-components/scss/globals/scss/colors';
+@import 'carbon-components/scss/globals/scss/vars';
+@import 'carbon-components/scss/globals/scss/helper-mixins';
+@import 'carbon-components/scss/globals/scss/layout';
+@import 'carbon-components/scss/globals/scss/layer';
+@import 'carbon-components/scss/globals/scss/typography';
+@import 'carbon-components/scss/globals/scss/import-once';
+@import 'carbon-components/scss/globals/scss/css--reset';
+@import 'carbon-components/scss/globals/scss/css--typography';
+@import 'carbon-components/scss/components/breadcrumb/breadcrumb';
+@import 'carbon-components/scss/components/overflow-menu/overflow-menu';
+@import 'carbon-components/scss/components/tabs/tabs';
 @import 'mixins';
 
 @include exports('detail-page-header') {

--- a/src/components/InteriorLeftNav/_interior-left-nav.scss
+++ b/src/components/InteriorLeftNav/_interior-left-nav.scss
@@ -1,11 +1,11 @@
-@import '../../../node_modules/carbon-components/scss/globals/scss/colors';
-@import '../../../node_modules/carbon-components/scss/globals/scss/vars';
-@import '../../../node_modules/carbon-components/scss/globals/scss/mixins';
-@import '../../../node_modules/carbon-components/scss/globals/scss/layer';
-@import '../../../node_modules/carbon-components/scss/globals/scss/typography';
-@import '../../../node_modules/carbon-components/scss/globals/scss/import-once';
-@import '../../../node_modules/carbon-components/scss/globals/scss/css--reset';
-@import '../../../node_modules/carbon-components/scss/globals/scss/css--typography';
+@import 'carbon-components/scss/globals/scss/colors';
+@import 'carbon-components/scss/globals/scss/vars';
+@import 'carbon-components/scss/globals/scss/mixins';
+@import 'carbon-components/scss/globals/scss/layer';
+@import 'carbon-components/scss/globals/scss/typography';
+@import 'carbon-components/scss/globals/scss/import-once';
+@import 'carbon-components/scss/globals/scss/css--reset';
+@import 'carbon-components/scss/globals/scss/css--typography';
 
 @include exports('interior-left-nav') {
   .bx--interior-left-nav {

--- a/src/components/Module/_module.scss
+++ b/src/components/Module/_module.scss
@@ -1,10 +1,10 @@
-@import '../../../node_modules/carbon-components/scss/globals/scss/colors';
-@import '../../../node_modules/carbon-components/scss/globals/scss/helper-mixins';
-@import '../../../node_modules/carbon-components/scss/globals/scss/layout';
-@import '../../../node_modules/carbon-components/scss/globals/scss/typography';
-@import '../../../node_modules/carbon-components/scss/globals/scss/import-once';
-@import '../../../node_modules/carbon-components/scss/globals/scss/css--reset';
-@import '../../../node_modules/carbon-components/scss/globals/scss/css--typography';
+@import 'carbon-components/scss/globals/scss/colors';
+@import 'carbon-components/scss/globals/scss/helper-mixins';
+@import 'carbon-components/scss/globals/scss/layout';
+@import 'carbon-components/scss/globals/scss/typography';
+@import 'carbon-components/scss/globals/scss/import-once';
+@import 'carbon-components/scss/globals/scss/css--reset';
+@import 'carbon-components/scss/globals/scss/css--typography';
 
 @include exports('modules') {
   .bx--module {

--- a/src/components/OrderSummary/_order-summary.scss
+++ b/src/components/OrderSummary/_order-summary.scss
@@ -1,6 +1,6 @@
-@import '../../../node_modules/carbon-components/scss/globals/scss/colors';
-@import '../../../node_modules/carbon-components/scss/globals/scss/mixins';
-@import '../../../node_modules/carbon-components/scss/components/dropdown/dropdown';
+@import 'carbon-components/scss/globals/scss/colors';
+@import 'carbon-components/scss/globals/scss/mixins';
+@import 'carbon-components/scss/components/dropdown/dropdown';
 
 @include exports('order-summary') {
   .bx--order-summary {


### PR DESCRIPTION
#### Changelog

**New**

**Changed**

- Cloud components now reference the right path in `carbon-components`
- README updated to include `includePaths` note.

**Removed**
