### PR TITLE
fix(InteriorLeftNav): more strict typecheck before wrapping child items

### DIFF
--- a/src/components/InteriorLeftNav/InteriorLeftNav.js
+++ b/src/components/InteriorLeftNav/InteriorLeftNav.js
@@ -99,8 +99,10 @@ export default class InteriorLeftNav extends Component {
       let newChild;
       if (child.type === InteriorLeftNavList) {
         newChild = this.buildNewListChild(child, index);
-      } else {
+      } else if (child.type === InteriorLeftNavItem) {
         newChild = this.buildNewItemChild(child, index);
+      } else {
+        newChild = child;
       }
 
       return newChild;


### PR DESCRIPTION
Found that ILN assumes the child nodes are `InteriorLeftNavList` or `InteriorLeftNavItem` when wrapping child nodes. It caused a hard-to-spot error when I inadvertently put something like `<div>`. This change is for better typecheck to avoid that situation.

#### Changelog

**Changed**

- Makes sure a child node of ILN is `InteriorLeftNavItem` before creating a wrapped version of it