### PR TITLE
fix(InteriorLeftNav): remove keypress handler

### DIFF
--- a/src/components/InteriorLeftNav/InteriorLeftNav.js
+++ b/src/components/InteriorLeftNav/InteriorLeftNav.js
@@ -128,7 +128,6 @@ export default class InteriorLeftNav extends Component {
         aria-label="Interior Left Navigation"
         className={classNames}
         onClick={!this.state.open ? this.toggle : () => {}}
-        onKeyPress={!this.state.open ? this.toggle : () => {}}
         {...other}>
         <ul key="main_list" className="left-nav-list" role="menubar">
           {newChildren}


### PR DESCRIPTION
Click handler seems to run upon keypress on the toggle button, and handling keypress causes running the event handler twice.

Fixes #21.

**Removed**

- The `keypress` handler on the toggle of `<InteriorLeftNav>`.