### PR TITLE
Remove default URL

### DIFF
--- a/src/components/CloudHeader/CloudHeaderLogo.js
+++ b/src/components/CloudHeader/CloudHeaderLogo.js
@@ -40,8 +40,7 @@ CloudHeaderLogo.propTypes = {
 
 CloudHeaderLogo.defaultProps = {
   companyName: 'IBM',
-  productName: 'Cloud',
-  href: 'https://www.ibm.com/cloud/',
+  productName: 'Cloud'
 };
 
 export default CloudHeaderLogo;


### PR DESCRIPTION
I don't think there should be a default URL, as I would like to implement a logo that doesn't have a HREF in my product. By not having a default, this allows for the lack of a href.

#### Changelog

**Changed**

- No longer a default url for the CloudHeader Logo
