### PR TITLE
fix(cloud-header): change from button to a11y-compliant divs

### DIFF
--- a/.storybook/_container.scss
+++ b/.storybook/_container.scss
@@ -19,8 +19,6 @@ $css--plex: true !default;
   position: absolute;
   right: 0;
   top: 100%;
-  min-height: 200px;
-  font-size: rem(18px);
 
   li {
     padding: 0.5rem;

--- a/src/components/CloudHeader/CloudHeader-story.js
+++ b/src/components/CloudHeader/CloudHeader-story.js
@@ -7,7 +7,7 @@ import CloudHeaderMenu from './CloudHeaderMenu';
 import CloudHeaderLogo from './CloudHeaderLogo';
 import CloudHeaderList from './CloudHeaderList';
 import CloudHeaderListItem from './CloudHeaderListItem';
-import { Search } from 'carbon-components-react';
+import { Search, Link } from 'carbon-components-react';
 
 storiesOf('CloudHeader', module).addWithInfo(
   'default',
@@ -101,29 +101,59 @@ storiesOf('CloudHeader', module).addWithInfo(
         )}
         renderNotification={() => (
           <ul className="list">
-            <li>Notification 1</li>
-            <li>Notification 2</li>
-            <li>Notification 3</li>
-            <li>Notification 4</li>
-            <li>Notification 5</li>
+            <li>
+              <Link href="www.google.com">Notification 1</Link>
+            </li>
+            <li>
+              <Link href="www.google.com">Notification 2</Link>
+            </li>
+            <li>
+              <Link href="www.google.com">Notification 3</Link>
+            </li>
+            <li>
+              <Link href="www.google.com">Notification 4</Link>
+            </li>
+            <li>
+              <Link href="www.google.com">Notification 5</Link>
+            </li>
           </ul>
         )}
         renderApplication={() => (
           <ul className="list">
-            <li>Application 1</li>
-            <li>Application 2</li>
-            <li>Application 3</li>
-            <li>Application 4</li>
-            <li>Application 5</li>
+            <li>
+              <Link href="www.google.com">Application 1</Link>
+            </li>
+            <li>
+              <Link href="www.google.com">Application 2</Link>
+            </li>
+            <li>
+              <Link href="www.google.com">Application 3</Link>
+            </li>
+            <li>
+              <Link href="www.google.com">Application 4</Link>
+            </li>
+            <li>
+              <Link href="www.google.com">Application 5</Link>
+            </li>
           </ul>
         )}
         renderUser={() => (
           <ul className="list">
-            <li>User 1</li>
-            <li>User 2</li>
-            <li>User 3</li>
-            <li>User 4</li>
-            <li>User 5</li>
+            <li>
+              <Link href="www.google.com">User 1</Link>
+            </li>
+            <li>
+              <Link href="www.google.com">User 2</Link>
+            </li>
+            <li>
+              <Link href="www.google.com">User 3</Link>
+            </li>
+            <li>
+              <Link href="www.google.com">User 4</Link>
+            </li>
+            <li>
+              <Link href="www.google.com">User 5</Link>
+            </li>
           </ul>
         )}
         renderLogo={() => logo}

--- a/src/components/CloudHeader/CloudHeader.js
+++ b/src/components/CloudHeader/CloudHeader.js
@@ -54,6 +54,14 @@ export default class CloudHeader extends React.Component {
     isUserActive: false,
   };
 
+  handleIconKeypress = type => evt => {
+    if (evt.which === 13 || evt.which === 32) {
+      if (evt.target.classList.contains('bx--cloud-header-list__btn')) {
+        this.handleIconClick(type, evt)();
+      }
+    }
+  };
+
   handleIconClick = type => evt => {
     Object.keys(this.state).forEach(key => {
       const clickType = `is${type}Active`;
@@ -137,6 +145,8 @@ export default class CloudHeader extends React.Component {
             {renderSearch && (
               <CloudHeaderListItem
                 onClick={this.handleIconClick('Search')}
+                onKeyDown={this.handleIconKeypress('Search')}
+                ariaExpanded={this.state.isSearchActive}
                 isIcon>
                 {searchIcon}
               </CloudHeaderListItem>
@@ -144,6 +154,8 @@ export default class CloudHeader extends React.Component {
             {renderNotification && (
               <CloudHeaderListItem
                 onClick={this.handleIconClick('Notification')}
+                onKeyDown={this.handleIconKeypress('Notification')}
+                ariaExpanded={this.state.isNotificationActive}
                 isIcon>
                 {notificationIcon}
                 {isNotificationActive && renderNotification()}
@@ -152,6 +164,8 @@ export default class CloudHeader extends React.Component {
             {renderApplication && (
               <CloudHeaderListItem
                 onClick={this.handleIconClick('Application')}
+                onKeyDown={this.handleIconKeypress('Application')}
+                ariaExpanded={this.state.isApplicationActive}
                 isIcon>
                 {applicationIcon}
                 {isApplicationActive && renderApplication()}
@@ -160,6 +174,8 @@ export default class CloudHeader extends React.Component {
             {renderUser && (
               <CloudHeaderListItem
                 onClick={this.handleIconClick('User')}
+                onKeyDown={this.handleIconKeypress('User')}
+                ariaExpanded={this.state.isUserActive}
                 isIcon>
                 {userIcon}
                 {isUserActive && renderUser()}

--- a/src/components/CloudHeader/CloudHeaderListItem.js
+++ b/src/components/CloudHeader/CloudHeaderListItem.js
@@ -3,7 +3,7 @@ import React from 'react';
 import classNames from 'classnames';
 
 const CloudHeaderListItem = props => {
-  const { children, className, href, isIcon, ...other } = props;
+  const { children, className, href, isIcon, ariaExpanded, ...other } = props;
 
   const CloudHeaderListItemClasses = classNames(
     'bx--cloud-header-list__item',
@@ -16,9 +16,15 @@ const CloudHeaderListItem = props => {
   return (
     <li className={CloudHeaderListItemClasses}>
       {isIcon ? (
-        <button className="bx--cloud-header-list__btn" type="button" {...other}>
+        <div
+          aria-expanded={ariaExpanded}
+          aria-haspopup="true"
+          role="button"
+          tabIndex="0"
+          className="bx--cloud-header-list__btn"
+          {...other}>
           {children}
-        </button>
+        </div>
       ) : (
         <a className="bx--cloud-header-list__link" href={href} {...other}>
           {children}

--- a/src/components/CloudHeader/CloudHeaderLogo.js
+++ b/src/components/CloudHeader/CloudHeaderLogo.js
@@ -40,7 +40,7 @@ CloudHeaderLogo.propTypes = {
 
 CloudHeaderLogo.defaultProps = {
   companyName: 'IBM',
-  productName: 'Cloud'
+  productName: 'Cloud',
 };
 
 export default CloudHeaderLogo;

--- a/src/components/CloudHeader/__tests__/CloudHeaderListItem-test.js
+++ b/src/components/CloudHeader/__tests__/CloudHeaderListItem-test.js
@@ -21,13 +21,13 @@ describe('CloudHeaderListItem', () => {
       const a = list.find('a');
       expect(a.length).toEqual(1);
     });
-    it('should render a button if it is an icon', () => {
+    it('should render a div with role of button if it is an icon', () => {
       const buttonListItem = mount(
         <CloudHeaderListItem isIcon className="some-class">
           Catalog
         </CloudHeaderListItem>
       );
-      const button = buttonListItem.find('button');
+      const button = buttonListItem.find('div[role="button"]');
       expect(button.length).toEqual(1);
     });
   });

--- a/src/components/CloudHeader/_cloud-header.scss
+++ b/src/components/CloudHeader/_cloud-header.scss
@@ -119,7 +119,7 @@ $cloud-header-background-color: $color__blue-90 !default;
 }
 
 .bx--cloud-header-list__btn {
-  @include button-reset;
+  cursor: pointer;
   display: flex;
   align-items: center;
   height: 100%;


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon-addons-cloud/issues/31

Small fixes and enhancements for `CloudHeader`

#### Changelog

**New**
- Updated story to use `Link` components to demonstrate a more real scenario

**Changed**
- Changed the Icon's on the right side to be `div`'s instead of buttons, as having a `dropdown` position absolutely _within_ a button was causing click issues in Firefox. Buttons have been switched to `div` with correct `a11y` attributes to act just like a button, just without the wonkiness. 
- Improved keyboard `a11y`

**Removed**
- Extra styles