### PR TITLE
fix(order-summary): change OrderSummaryListItem from p to div

### DIFF
--- a/src/components/OrderSummary/OrderSummary.js
+++ b/src/components/OrderSummary/OrderSummary.js
@@ -105,7 +105,7 @@ export class OrderSummaryListItem extends Component {
 
     return (
       <li className={classes} {...other}>
-        <p className="bx--order-detail">{text}</p>
+        <div className="bx--order-detail">{text}</div>
         <p className="bx--order-price">{price}</p>
       </li>
     );


### PR DESCRIPTION
Refs https://github.com/carbon-design-system/carbon-addons-cloud/issues/45

**Changed**

- Changed `p` to `div` so the console doesn't throw warnings when `Tooltip` is nested inside `OrderSummaryListItem`
