### PR TITLE
feat(cloud-header): make HOA updates to Cloud Header

### DIFF
--- a/src/components/CloudHeader/CloudHeader-story.js
+++ b/src/components/CloudHeader/CloudHeader-story.js
@@ -15,80 +15,16 @@ storiesOf('CloudHeader', module).addWithInfo(
       Basic implementation of the Cloud Header
     `,
   () => {
-    const logo = (
-      <svg
-        data-name="Layer 1"
-        xmlns="http://www.w3.org/2000/svg"
-        viewBox="0 0 275.76529 243.9836">
-        <defs>
-          <linearGradient
-            id="a"
-            x1="4979.474"
-            y1="10122.533"
-            x2="5087.703"
-            y2="10103.45"
-            gradientTransform="scale(-1 1) rotate(-45 -9605.065 11330.987)"
-            gradientUnits="userSpaceOnUse">
-            <stop stopColor="#fff" offset=".2" stopOpacity="0" />
-            <stop stopColor="#fff" offset=".287" stopOpacity=".03" />
-            <stop stopColor="#fff" offset=".501" stopOpacity=".2" />
-            <stop stopColor="#fff" offset=".793" stopOpacity=".742" />
-            <stop stopColor="#fff" offset="1" />
-          </linearGradient>
-          <linearGradient
-            id="b"
-            x1="-.357"
-            y1="51.748"
-            x2="63.087"
-            y2="88.378"
-            gradientTransform="matrix(1 0 0 -1 -5.791 224.135)"
-            gradientUnits="userSpaceOnUse">
-            <stop stopColor="#fff" offset=".08" />
-            <stop stopColor="#fff" offset=".753" stopOpacity=".07" />
-            <stop stopColor="#fff" offset=".875" stopOpacity="0" />
-          </linearGradient>
-          <linearGradient
-            id="c"
-            x1="144.665"
-            y1="44.837"
-            x2="241.172"
-            y2="125.816"
-            gradientTransform="matrix(1 0 0 -1 -5.791 224.135)"
-            gradientUnits="userSpaceOnUse">
-            <stop stopColor="#fff" offset=".138" stopOpacity="0" />
-            <stop stopColor="#fff" offset=".32" stopOpacity=".07" />
-            <stop stopColor="#fff" offset=".847" stopOpacity=".764" />
-            <stop stopColor="#fff" offset=".947" />
-          </linearGradient>
-        </defs>
-        <path
-          fill="#fff"
-          d="M36.697 97.367a5.195 5.195 0 0 1-2.604-.7L9.19 82.288a5.217 5.217 0 1 1 5.217-9.037L39.31 87.63a5.218 5.218 0 0 1-2.613 9.737zm42.596-42.586a5.215 5.215 0 0 1-4.524-2.61L60.39 27.268a5.218 5.218 0 0 1 9.037-5.218l14.38 24.905a5.219 5.219 0 0 1-4.514 7.827zm58.167-15.589a5.217 5.217 0 0 1-5.217-5.217V5.217a5.218 5.218 0 0 1 10.435 0v28.758a5.217 5.217 0 0 1-5.217 5.217zm58.17 15.589a5.219 5.219 0 0 1-4.514-7.827l14.379-24.905a5.218 5.218 0 0 1 9.037 5.218l-14.379 24.905a5.216 5.216 0 0 1-4.523 2.61zm42.595 42.586a5.218 5.218 0 0 1-2.613-9.737l24.904-14.379a5.217 5.217 0 1 1 5.217 9.037L240.83 96.667a5.195 5.195 0 0 1-2.604.7z"
-        />
-        <path
-          fill="url(#a)"
-          d="M71.232 216.548A93.66 93.66 0 0 1 203.687 84.09a95.03 95.03 0 0 1 7.451 8.388 93.907 93.907 0 0 1 4.55 6.303l-8.709 5.748a83.29 83.29 0 0 0-4.04-5.597 84.494 84.494 0 0 0-6.628-7.46 83.226 83.226 0 0 0-117.698 117.7z"
-        />
-        <path
-          fill="#fff"
-          d="M204.23 243.984c-.183 0-.364 0-.548-.002h-143.6a60.495 60.495 0 0 1-60.08-60.944l10.435.078a50.058 50.058 0 0 0 49.685 50.43h143.6c.152.002.31.003.462.003a61.117 61.117 0 0 0 45.582-101.861l7.778-6.957a71.552 71.552 0 0 1-53.315 119.253z"
-        />
-        <path
-          fill="url(#b)"
-          d="M10.437 183.116l-10.435-.078a60.43 60.43 0 0 1 50.409-59.207l1.742 10.29a50.006 50.006 0 0 0-41.716 48.995z"
-        />
-        <path
-          fill="url(#c)"
-          d="M143.102 171.978l-10.435-.079a71.55 71.55 0 0 1 124.877-47.169l-7.778 6.957a61.115 61.115 0 0 0-106.664 40.29z"
-        />
-      </svg>
-    );
-
     return (
       <CloudHeader
         companyName="IBM"
         productName="Cloud"
         logoHref="https://www.ibm.com/cloud/"
+        links={[
+          { href: 'www.google.com', linkText: 'Catalog' },
+          { href: 'www.google.com', linkText: 'Support' },
+          { href: 'www.google.com', linkText: 'Manage' },
+        ]}
         renderMenu={() => <span>Menu</span>}
         renderSearch={() => (
           <Search
@@ -118,22 +54,22 @@ storiesOf('CloudHeader', module).addWithInfo(
             </li>
           </ul>
         )}
-        renderApplication={() => (
+        renderHelp={() => (
           <ul className="list">
             <li>
-              <Link href="www.google.com">Application 1</Link>
+              <Link href="www.google.com">Help 1</Link>
             </li>
             <li>
-              <Link href="www.google.com">Application 2</Link>
+              <Link href="www.google.com">Help 2</Link>
             </li>
             <li>
-              <Link href="www.google.com">Application 3</Link>
+              <Link href="www.google.com">Help 3</Link>
             </li>
             <li>
-              <Link href="www.google.com">Application 4</Link>
+              <Link href="www.google.com">Help 4</Link>
             </li>
             <li>
-              <Link href="www.google.com">Application 5</Link>
+              <Link href="www.google.com">Help 5</Link>
             </li>
           </ul>
         )}
@@ -156,12 +92,6 @@ storiesOf('CloudHeader', module).addWithInfo(
             </li>
           </ul>
         )}
-        renderLogo={() => logo}
-        links={[
-          { href: 'www.google.com', linkText: 'Catalog' },
-          { href: 'www.google.com', linkText: 'Support' },
-          { href: 'www.google.com', linkText: 'Manage' },
-        ]}
       />
     );
   }

--- a/src/components/CloudHeader/CloudHeader.js
+++ b/src/components/CloudHeader/CloudHeader.js
@@ -9,17 +9,25 @@ import CloudHeaderList from './CloudHeaderList';
 import CloudHeaderListItem from './CloudHeaderListItem';
 
 const searchIcon = (
-  <svg viewBox="0 0 16 16" fillRule="evenodd">
+  <svg width="20" height="20">
     <title>search</title>
-    <path d="M6 2c2.2 0 4 1.8 4 4s-1.8 4-4 4-4-1.8-4-4 1.8-4 4-4zm0-2C2.7 0 0 2.7 0 6s2.7 6 6 6 6-2.7 6-6-2.7-6-6-6zm10 13.8L13.8 16l-3.6-3.6 2.2-2.2z" />
-    <path d="M16 13.8L13.8 16l-3.6-3.6 2.2-2.2z" />
+    <path d="M8.5 14a5.5 5.5 0 1 0 0-11 5.5 5.5 0 0 0 0 11zm4.936-1.27l4.418 4.416-.708.708-4.417-4.418a6.5 6.5 0 1 1 .707-.707z" />
   </svg>
 );
 
 const notificationIcon = (
-  <svg viewBox="0 0 16 16">
-    <title>notifications</title>
-    <path d="M9 1.11V0H7v1.11A5.022 5.022 0 0 0 3.1 4.9L1 14h5a2 2 0 0 0 4 0h5l-2.1-9.1A5.022 5.022 0 0 0 9 1.11z" />
+  <svg width="20" height="20">
+    <title>notification</title>
+    <path d="M7.17 17H2.5a.5.5 0 0 1-.5-.5v-2a.5.5 0 0 1 .146-.354L4 12.293V9a6 6 0 0 1 5.5-5.98V1h1v2.02A6 6 0 0 1 16 9v3.293l1.854 1.853A.5.5 0 0 1 18 14.5v2a.5.5 0 0 1-.5.5h-4.67a3.001 3.001 0 0 1-5.66 0zm1.098 0a2 2 0 0 0 3.464 0H8.268zM13 16h4v-1.293l-1.854-1.853A.5.5 0 0 1 15 12.5V9A5 5 0 0 0 5 9v3.5a.5.5 0 0 1-.146.354L3 14.707V16h10z" />
+  </svg>
+);
+
+const helpIcon = (
+  <svg width="20" height="20">
+    <title>help</title>
+    <path d="M10 17a7 7 0 1 0 0-14 7 7 0 0 0 0 14zm0 1a8 8 0 1 1 0-16 8 8 0 0 1 0 16z" fillRule="nonzero" />
+    <circle cx="10" cy="14" r="1" />
+    <path d="M10.5 10.5V12h-1V9.5h1a1.5 1.5 0 0 0 0-3h-1A1.5 1.5 0 0 0 8 8H7a2.5 2.5 0 0 1 2.5-2.5h1a2.5 2.5 0 1 1 0 5z" />
   </svg>
 );
 
@@ -39,9 +47,9 @@ const applicationIcon = (
 );
 
 const userIcon = (
-  <svg className="bx--cloud-header__user-icon" viewBox="0 0 24 24">
+  <svg width="20" height="20">
     <title>user</title>
-    <path d="M12 0C5.4 0 0 5.4 0 12s5.4 12 12 12 12-5.4 12-12S18.6 0 12 0zm0 4.6c2.8 0 5 2.2 5 5s-2.2 5-5 5-5-2.2-5-5 2.2-5 5-5zm7 14.5c-1.8 1.8-4.3 2.9-7 2.9s-5.2-1.1-7-2.9v-1.6c0-1.3.7-2 2-2h10c1.3 0 2 .7 2 2v1.6z" />
+    <path d="M6 15.745A6.968 6.968 0 0 0 10 17a6.968 6.968 0 0 0 4-1.255V15.5a2.5 2.5 0 0 0-2.5-2.5h-3A2.5 2.5 0 0 0 6 15.5v.245zm-.956-.802A3.5 3.5 0 0 1 8.5 12h3a3.5 3.5 0 0 1 3.456 2.943 7 7 0 1 0-9.912 0zM10 18a8 8 0 1 1 0-16 8 8 0 0 1 0 16z" /><path d="M10 9.841a2 2 0 1 0 0-4 2 2 0 0 0 0 4zm0 1a3 3 0 1 1 0-6 3 3 0 0 1 0 6z" />
   </svg>
 );
 
@@ -50,6 +58,7 @@ export default class CloudHeader extends React.Component {
     isMenuActive: false,
     isSearchActive: false,
     isNotificationActive: false,
+    isHelpActive: false,
     isApplicationActive: false,
     isUserActive: false,
   };
@@ -99,6 +108,7 @@ export default class CloudHeader extends React.Component {
       renderLogo,
       renderSearch,
       renderNotification,
+      renderHelp,
       renderApplication,
       renderUser,
       links,
@@ -109,6 +119,7 @@ export default class CloudHeader extends React.Component {
       isMenuActive,
       isSearchActive,
       isNotificationActive,
+      isHelpActive,
       isApplicationActive,
       isUserActive,
     } = this.state;
@@ -118,17 +129,19 @@ export default class CloudHeader extends React.Component {
     return (
       <nav key="nav" className={cloudHeaderClasses} {...other}>
         <CloudHeaderWrapper>
-          {renderMenu && (
-            <CloudHeaderMenu onClick={this.handleIconClick('Menu')} />
-          )}
-          <CloudHeaderLogo
-            className={!renderMenu ? 'bx--cloud-header-brand--no-menu' : null}
-            companyName={companyName}
-            productName={productName}
-            href={logoHref}>
-            {renderLogo && renderLogo()}
-          </CloudHeaderLogo>
-          <CloudHeaderList>
+          <div className="bx--cloud-header-brand-container">
+            {renderMenu && (
+              <CloudHeaderMenu onClick={this.handleIconClick('Menu')} />
+            )}
+            <CloudHeaderLogo
+              className={!renderMenu ? 'bx--cloud-header-brand--no-menu' : null}
+              companyName={companyName}
+              productName={productName}
+              href={logoHref}>
+              {renderLogo && renderLogo()}
+            </CloudHeaderLogo>
+          </div>
+          <CloudHeaderList className="bx--cloud-header-list--link">
             {links &&
               links.map((link, i) => {
                 return (
@@ -138,10 +151,10 @@ export default class CloudHeader extends React.Component {
                 );
               })}
           </CloudHeaderList>
-        </CloudHeaderWrapper>
+        </CloudHeaderWrapper >
         <CloudHeaderWrapper>
           {isSearchActive && renderSearch && renderSearch()}
-          <CloudHeaderList>
+          <CloudHeaderList className="bx--cloud-header-list--icon">
             {renderSearch && (
               <CloudHeaderListItem
                 onClick={this.handleIconClick('Search')}
@@ -161,6 +174,16 @@ export default class CloudHeader extends React.Component {
                 {isNotificationActive && renderNotification()}
               </CloudHeaderListItem>
             )}
+            {renderHelp && (
+              <CloudHeaderListItem
+                onClick={this.handleIconClick('Help')}
+                onKeyDown={this.handleIconKeypress('Help')}
+                ariaExpanded={this.state.isHelpActive}
+                isIcon>
+                {helpIcon}
+                {isHelpActive && renderHelp()}
+              </CloudHeaderListItem>
+            )}
             {renderApplication && (
               <CloudHeaderListItem
                 onClick={this.handleIconClick('Application')}
@@ -173,6 +196,7 @@ export default class CloudHeader extends React.Component {
             )}
             {renderUser && (
               <CloudHeaderListItem
+                className="bx--cloud-header-list__item--icon"
                 onClick={this.handleIconClick('User')}
                 onKeyDown={this.handleIconKeypress('User')}
                 ariaExpanded={this.state.isUserActive}
@@ -184,7 +208,7 @@ export default class CloudHeader extends React.Component {
           </CloudHeaderList>
         </CloudHeaderWrapper>
         {isMenuActive && ReactDOM.createPortal(renderMenu(), this.portalNode)}
-      </nav>
+      </nav >
     );
   }
 }

--- a/src/components/CloudHeader/CloudHeaderListItem.js
+++ b/src/components/CloudHeader/CloudHeaderListItem.js
@@ -7,7 +7,6 @@ const CloudHeaderListItem = props => {
 
   const CloudHeaderListItemClasses = classNames(
     'bx--cloud-header-list__item',
-    isIcon ? 'bx--cloud-header-list__item--icon' : null,
     className
   );
 
@@ -26,10 +25,10 @@ const CloudHeaderListItem = props => {
           {children}
         </div>
       ) : (
-        <a className="bx--cloud-header-list__link" href={href} {...other}>
-          {children}
-        </a>
-      )}
+          <a className="bx--cloud-header-list__link" href={href} {...other}>
+            {children}
+          </a>
+        )}
     </li>
   );
 };
@@ -38,11 +37,9 @@ CloudHeaderListItem.propTypes = {
   children: PropTypes.node,
   className: PropTypes.string,
   href: PropTypes.string,
-  isIcon: PropTypes.bool,
 };
 
 CloudHeaderListItem.defaultProps = {
-  isIcon: false,
   href: '',
 };
 

--- a/src/components/CloudHeader/CloudHeaderMenu.js
+++ b/src/components/CloudHeader/CloudHeaderMenu.js
@@ -12,9 +12,9 @@ const CloudHeaderMenu = props => {
 
   return (
     <button className={cloudHeaderMenuClasses} type="button" {...other}>
-      <svg fillRule="evenodd">
+      <svg width="20" height="20">
         <title>cloud header menu</title>
-        <path d="M0 0h20v2H0zm0 6h20v2H0zm0 6h20v2H0z" />
+        <path d="M3 4h14v1H3zM3 10h14v1H3zM3 16h14v1H3z" />
       </svg>
     </button>
   );

--- a/src/components/CloudHeader/_cloud-header.scss
+++ b/src/components/CloudHeader/_cloud-header.scss
@@ -1,10 +1,12 @@
 @import 'carbon-components/scss/globals/scss/colors';
 @import 'carbon-components/scss/globals/scss/helper-mixins';
 
-$cloud-header-link-color: $inverse-01 !default;
-$cloud-header-icon-color: $inverse-01 !default;
-$cloud-header-menu-color: $brand-02 !default;
+$cloud-header-link-color: #F2F4F8 !default;
+$cloud-header-icon-color: #F2F4F8 !default;
+$cloud-header-menu-color: #F2F4F8 !default;
 $cloud-header-background-color: $color__blue-90 !default;
+$cloud-header-hover-background-color: #2C3F48 !default;
+$cloud-header-hover-link-color: #76AAEA !default;
 
 .bx--cloud-header {
   display: flex;
@@ -13,14 +15,20 @@ $cloud-header-background-color: $color__blue-90 !default;
   background-color: $cloud-header-background-color;
   color: $cloud-header-link-color;
   height: rem(48px);
+  padding: 0 rem(2px);
   width: 100%;
 }
 
 .bx--cloud-header__wrapper,
-.bx--cloud-header-brand {
+.bx--cloud-header-brand,
+.bx--cloud-header-brand-container {
   height: 100%;
   display: flex;
   align-items: center;
+}
+
+.bx--cloud-header-brand-container {
+  width: rem(272px);
 }
 
 .bx--cloud-header__app-menu {
@@ -29,18 +37,22 @@ $cloud-header-background-color: $color__blue-90 !default;
   display: inline-flex;
   justify-content: center;
   align-items: center;
-  padding: 0 rem(24px);
-  height: 100%;
-  width: rem(16px);
+  padding: rem(14px);
+  margin-right: rem(10px);
+  width: auto;
+  transition: background-color $transition--base $bx--standard-easing;
 
   svg {
     fill: $cloud-header-menu-color;
-    width: rem(16px);
-    height: rem(16px);
   }
 
   &:focus {
     @include focus-outline('border');
+  }
+
+  &:hover,
+  &:focus {
+    background-color: $cloud-header-hover-background-color;
   }
 }
 
@@ -48,11 +60,10 @@ $cloud-header-background-color: $color__blue-90 !default;
   text-decoration: none;
   color: $cloud-header-link-color;
   transition: color $transition--base $bx--standard-easing;
-  padding-right: rem(16px);
 
   &:hover,
   &:focus {
-    color: $cloud-header-menu-color;
+    color: $cloud-header-hover-link-color;
   }
 
   &:focus {
@@ -71,6 +82,7 @@ $cloud-header-background-color: $color__blue-90 !default;
 }
 
 .bx--cloud-header-brand__text {
+  @include typescale('epsilon');
   font-weight: 400;
 
   span {
@@ -86,6 +98,22 @@ $cloud-header-background-color: $color__blue-90 !default;
   padding: 0;
 }
 
+.bx--cloud-header-list--link {
+  display: none;
+
+  @include breakpoint('672px') {
+    display: flex;
+  }
+}
+
+.bx--cloud-header-list--icon .bx--cloud-header-list__item:not(.bx--cloud-header-list__item--icon) {
+  display: none;
+
+  @include breakpoint('320px') {
+    display: flex;
+  }
+}
+
 .bx--cloud-header-list__item {
   height: 100%;
   display: flex;
@@ -93,13 +121,8 @@ $cloud-header-background-color: $color__blue-90 !default;
   position: relative;
 }
 
-.bx--cloud-header-list__item--icon {
-  padding: 0;
-}
-
 .bx--cloud-header-list__link {
-  @include typescale('zeta');
-  padding: 0 rem(16px);
+  @include typescale('epsilon');
   height: 100%;
   display: flex;
   align-items: center;
@@ -107,10 +130,11 @@ $cloud-header-background-color: $color__blue-90 !default;
   color: $cloud-header-link-color;
   text-decoration: none;
   transition: color $transition--base $bx--standard-easing;
+  margin-right: rem(32px);
 
   &:hover,
   &:focus {
-    color: $cloud-header-menu-color;
+    color: $cloud-header-hover-link-color;
   }
 
   &:focus {
@@ -123,18 +147,16 @@ $cloud-header-background-color: $color__blue-90 !default;
   display: flex;
   align-items: center;
   height: 100%;
-  padding: 0 rem(16px);
+  padding: rem(14px);
+  transition: background-color $transition--base $bx--standard-easing;
 
   svg {
     fill: $cloud-header-icon-color;
-    height: rem(16px);
-    width: rem(16px);
-    transition: fill $transition--base $bx--standard-easing;
   }
 
-  &:hover svg,
-  &:focus svg {
-    fill: $cloud-header-menu-color;
+  &:hover,
+  &:focus {
+    background-color: $cloud-header-hover-background-color;
   }
 
   &:focus {


### PR DESCRIPTION
Closes https://github.ibm.com/carbon/issues/issues/700

This PR addresses minor icon updates/color changes. Also adds some responsiveness to the overall Cloud Header

![header](https://user-images.githubusercontent.com/11928039/40137204-6d106110-590f-11e8-8e8f-952ea73bc661.gif)


#### Changelog

**New**
- New icons
- New hover colors
- `renderHelp` is a new function that renders the Help Icon, along with a place to put help content
- IBM Cloud  + hamburger menu wrapping container 

**Changed**
- Font size is `16px` across the board
- Replaced icons
- `renderApplication` is no longer shown in the storybook, but the function itself is still available 

**Removed**
- IBM Cloud logo
- Extra CSS classes


**Testing**
- Check that `CloudHeader` matches the specs in the linked issue