### PR TITLE
fix: updating peerDependencies and devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,14 +24,16 @@
     "test": "jest"
   },
   "dependencies": {
-    "carbon-components": "^8.11.1",
-    "carbon-components-react": "^5.19.0",
-    "carbon-icons": "^6.2.0",
     "classnames": "^2.2.5",
     "prop-types": "^15.6.0",
-    "react": "^16.1.0",
-    "react-dom": "^16.1.0",
     "window-or-global": "^1.0.1"
+  },
+  "peerDependencies": {
+    "carbon-components": "^8.11.1",
+    "carbon-components-react": "^5.19.0",
+    "carbon-icons": "^5.1.2 || ^6.2.0",
+    "react": "^15.3.2 || ^16.1.0",
+    "react-dom": "^15.3.2 || ^16.1.0"
   },
   "devDependencies": {
     "@storybook/addon-actions": "^3.2.15",
@@ -48,6 +50,9 @@
     "babel-preset-react": "^6.24.1",
     "babel-preset-stage-1": "^6.24.1",
     "babel-runtime": "^6.26.0",
+    "carbon-components": "^8.11.1",
+    "carbon-components-react": "^5.19.0",
+    "carbon-icons": "^6.2.0",
     "cpx": "^1.5.0",
     "css-loader": "^0.28.7",
     "enzyme": "^3.1.1",
@@ -61,6 +66,8 @@
     "postcss-loader": "^2.0.8",
     "prettier": "^1.10.0",
     "promise": "^8.0.1",
+    "react": "^16.1.0",
+    "react-dom": "^16.1.0",
     "rimraf": "^2.6.2",
     "sass-loader": "^6.0.6",
     "semantic-release": "^15.0.1",

--- a/src/components/InteriorLeftNav/_interior-left-nav.scss
+++ b/src/components/InteriorLeftNav/_interior-left-nav.scss
@@ -28,7 +28,7 @@
       flex-direction: column;
       background-color: $color__white;
       padding-top: 1.5rem;
-      overflow: auto;
+      overflow: visible;
 
       &__item {
         cursor: pointer;

--- a/src/index.js
+++ b/src/index.js
@@ -13,6 +13,7 @@ export DetailPageHeader from './components/DetailPageHeader';
 export InteriorLeftNav from './components/InteriorLeftNav';
 export InteriorLeftNavItem from './components/InteriorLeftNavItem';
 export InteriorLeftNavList from './components/InteriorLeftNavList';
+export InteriorLeftNavHeader from './components/InteriorLeftNavHeader';
 
 export { Module, ModuleBody, ModuleHeader } from './components/Module';
 


### PR DESCRIPTION
Changes in this PR:

- moves the carbon and react dependencies to `peerDependencies` and `devDependencies` in package.json.  
- `InteriorLeftNavHeader` component is also now exported.
- A small SCSS change was done to `.left-nav-list` to be `overflow: visible` to prevent a vertical scroll bar from appearing then disappearing when expanding a nav list option.