### PR TITLE
fix: adding aria-label for InteriorLeftNavList ul

### DIFF
--- a/src/components/InteriorLeftNavList/InteriorLeftNavList.js
+++ b/src/components/InteriorLeftNavList/InteriorLeftNavList.js
@@ -105,6 +105,7 @@ export default class InteriorLeftNavList extends Component {
         <ul
           role="menu"
           className="left-nav-list left-nav-list--nested"
+          aria-label={title}
           aria-hidden>
           {newChildren}
         </ul>


### PR DESCRIPTION
This PR adds the `aria-label` attribute to the `InteriorLeftNavList` component's `ul` tag to fix accessibility test failures.

This tag is already on the `InteriorLeftNavList` in the `carbon-components-react` repo at https://github.com/carbon-design-system/carbon-components-react/blob/master/src/components/InteriorLeftNavList/InteriorLeftNavList.js#L108