### PR TITLE
fix: revert ul on .left-nav-list to overflow auto

### DIFF
--- a/src/components/InteriorLeftNav/_interior-left-nav.scss
+++ b/src/components/InteriorLeftNav/_interior-left-nav.scss
@@ -28,7 +28,7 @@
       flex-direction: column;
       background-color: $color__white;
       padding-top: 1.5rem;
-      overflow: visible;
+      overflow: auto;
 
       &__item {
         cursor: pointer;


### PR DESCRIPTION
This PR reverts a previous change I did to `overflow` property to `.left-nav-list`; it changes it back to `overflow: auto` so if the left nav bar is too short to show the content it will allow vertical scrolling.