### PR TITLE
fix(tag-list): add cursor property to tag list edit buttton

### DIFF
--- a/src/components/tag-list/_tag-list.scss
+++ b/src/components/tag-list/_tag-list.scss
@@ -38,6 +38,7 @@
     background-color: transparent;
     border: none;
     padding: 0;
+    cursor: pointer;
   }
 
   .#{$prefix}--tag-list--edit--icon {


### PR DESCRIPTION
Really small change that's just been bothering me. Adds a cursor pointer property to the tag-list edit button.

**Changed**

- Adds cursor pointer property to tag list button