### PR TITLE
fix: use node tilde sass importer to resolve peer dep styles

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -7,6 +7,7 @@ const path = require('path');
 const rename = require('gulp-rename');
 const sass = require('gulp-sass');
 const sourcemaps = require('gulp-sourcemaps');
+const tildeImporter = require('node-sass-tilde-importer');
 
 fractal.set('project.title', 'carbon-addons-cloud');
 
@@ -77,6 +78,7 @@ gulp.task('styles:copy', ['clean'], () => {
 gulp.task('styles:build', ['clean', 'styles:copy'], () => {
   const config = {
     includePaths: [path.resolve(__dirname, './node_modules')],
+    importer: tildeImporter,
   };
   return Promise.all([
     gulp

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "jest": "^23.1.0",
     "lint-staged": "^7.1.2",
     "node-sass": "^4.9.0",
+    "node-sass-tilde-importer": "^1.0.2",
     "prettier": "^1.13.3",
     "semantic-release": "^15.5.0"
   },

--- a/src/__tests__/styles-test.js
+++ b/src/__tests__/styles-test.js
@@ -6,9 +6,11 @@
 
 const path = require('path');
 const sass = require('node-sass');
+const tildeImporter = require('node-sass-tilde-importer');
 
 const defaultOptions = {
   includePaths: ['node_modules'],
+  importer: tildeImporter,
 };
 
 describe('carbon-addons-cloud', () => {

--- a/src/components/card/_card.scss
+++ b/src/components/card/_card.scss
@@ -1,15 +1,15 @@
-@import 'carbon-components/scss/globals/scss/colors';
-@import 'carbon-components/scss/globals/scss/theme';
-@import 'carbon-components/scss/globals/scss/helper-mixins';
-@import 'carbon-components/scss/globals/scss/layout';
-@import 'carbon-components/scss/globals/scss/layer';
-@import 'carbon-components/scss/globals/scss/typography';
-@import 'carbon-components/scss/globals/scss/import-once';
-@import 'carbon-components/scss/globals/scss/css--reset';
-@import 'carbon-components/scss/globals/scss/css--typography';
-@import 'carbon-components/scss/components/overflow-menu/overflow-menu';
-@import 'carbon-components/scss/components/button/button';
-@import 'carbon-components/scss/components/link/link';
+@import '~carbon-components/scss/globals/scss/colors';
+@import '~carbon-components/scss/globals/scss/theme';
+@import '~carbon-components/scss/globals/scss/helper-mixins';
+@import '~carbon-components/scss/globals/scss/layout';
+@import '~carbon-components/scss/globals/scss/layer';
+@import '~carbon-components/scss/globals/scss/typography';
+@import '~carbon-components/scss/globals/scss/import-once';
+@import '~carbon-components/scss/globals/scss/css--reset';
+@import '~carbon-components/scss/globals/scss/css--typography';
+@import '~carbon-components/scss/components/overflow-menu/overflow-menu';
+@import '~carbon-components/scss/components/button/button';
+@import '~carbon-components/scss/components/link/link';
 @import 'mixins';
 
 @include exports('cloud-card') {

--- a/src/components/cloud-header/_cloud-header.scss
+++ b/src/components/cloud-header/_cloud-header.scss
@@ -1,6 +1,6 @@
-@import 'carbon-components/scss/globals/scss/colors';
-@import 'carbon-components/scss/globals/scss/theme';
-@import 'carbon-components/scss/globals/scss/helper-mixins';
+@import '~carbon-components/scss/globals/scss/colors';
+@import '~carbon-components/scss/globals/scss/theme';
+@import '~carbon-components/scss/globals/scss/helper-mixins';
 
 $cloud-header-link-color: #f2f4f8 !default;
 $cloud-header-icon-color: #f2f4f8 !default;

--- a/src/components/detail-page-header/_detail-page-header.scss
+++ b/src/components/detail-page-header/_detail-page-header.scss
@@ -1,16 +1,16 @@
-@import 'carbon-components/scss/globals/scss/colors';
-@import 'carbon-components/scss/globals/scss/theme';
-@import 'carbon-components/scss/globals/scss/vars';
-@import 'carbon-components/scss/globals/scss/helper-mixins';
-@import 'carbon-components/scss/globals/scss/layout';
-@import 'carbon-components/scss/globals/scss/layer';
-@import 'carbon-components/scss/globals/scss/typography';
-@import 'carbon-components/scss/globals/scss/import-once';
-@import 'carbon-components/scss/globals/scss/css--reset';
-@import 'carbon-components/scss/globals/scss/css--typography';
-@import 'carbon-components/scss/components/breadcrumb/breadcrumb';
-@import 'carbon-components/scss/components/overflow-menu/overflow-menu';
-@import 'carbon-components/scss/components/tabs/tabs';
+@import '~carbon-components/scss/globals/scss/colors';
+@import '~carbon-components/scss/globals/scss/theme';
+@import '~carbon-components/scss/globals/scss/vars';
+@import '~carbon-components/scss/globals/scss/helper-mixins';
+@import '~carbon-components/scss/globals/scss/layout';
+@import '~carbon-components/scss/globals/scss/layer';
+@import '~carbon-components/scss/globals/scss/typography';
+@import '~carbon-components/scss/globals/scss/import-once';
+@import '~carbon-components/scss/globals/scss/css--reset';
+@import '~carbon-components/scss/globals/scss/css--typography';
+@import '~carbon-components/scss/components/breadcrumb/breadcrumb';
+@import '~carbon-components/scss/components/overflow-menu/overflow-menu';
+@import '~carbon-components/scss/components/tabs/tabs';
 @import 'mixins';
 
 @include exports('cloud-detail-page-header') {

--- a/src/components/interior-left-nav/_interior-left-nav.scss
+++ b/src/components/interior-left-nav/_interior-left-nav.scss
@@ -1,12 +1,12 @@
-@import 'carbon-components/scss/globals/scss/colors';
-@import 'carbon-components/scss/globals/scss/theme';
-@import 'carbon-components/scss/globals/scss/vars';
-@import 'carbon-components/scss/globals/scss/mixins';
-@import 'carbon-components/scss/globals/scss/layer';
-@import 'carbon-components/scss/globals/scss/typography';
-@import 'carbon-components/scss/globals/scss/import-once';
-@import 'carbon-components/scss/globals/scss/css--reset';
-@import 'carbon-components/scss/globals/scss/css--typography';
+@import '~carbon-components/scss/globals/scss/colors';
+@import '~carbon-components/scss/globals/scss/theme';
+@import '~carbon-components/scss/globals/scss/vars';
+@import '~carbon-components/scss/globals/scss/mixins';
+@import '~carbon-components/scss/globals/scss/layer';
+@import '~carbon-components/scss/globals/scss/typography';
+@import '~carbon-components/scss/globals/scss/import-once';
+@import '~carbon-components/scss/globals/scss/css--reset';
+@import '~carbon-components/scss/globals/scss/css--typography';
 
 @include exports('cloud-interior-left-nav') {
   .bx--interior-left-nav {

--- a/src/components/loading/_loading.scss
+++ b/src/components/loading/_loading.scss
@@ -1,7 +1,7 @@
-@import 'carbon-components/scss/globals/scss/vars';
-@import 'carbon-components/scss/globals/scss/helper-mixins';
-@import 'carbon-components/scss/globals/scss/typography';
-@import 'carbon-components/scss/globals/scss/import-once';
+@import '~carbon-components/scss/globals/scss/vars';
+@import '~carbon-components/scss/globals/scss/helper-mixins';
+@import '~carbon-components/scss/globals/scss/typography';
+@import '~carbon-components/scss/globals/scss/import-once';
 @import 'vars';
 @import 'keyframes';
 

--- a/src/components/module/_module.scss
+++ b/src/components/module/_module.scss
@@ -1,12 +1,12 @@
-@import 'carbon-components/scss/globals/scss/colors';
-@import 'carbon-components/scss/globals/scss/theme';
-@import 'carbon-components/scss/globals/scss/helper-mixins';
-@import 'carbon-components/scss/globals/scss/layout';
-@import 'carbon-components/scss/globals/scss/layer';
-@import 'carbon-components/scss/globals/scss/typography';
-@import 'carbon-components/scss/globals/scss/import-once';
-@import 'carbon-components/scss/globals/scss/css--reset';
-@import 'carbon-components/scss/globals/scss/css--typography';
+@import '~carbon-components/scss/globals/scss/colors';
+@import '~carbon-components/scss/globals/scss/theme';
+@import '~carbon-components/scss/globals/scss/helper-mixins';
+@import '~carbon-components/scss/globals/scss/layout';
+@import '~carbon-components/scss/globals/scss/layer';
+@import '~carbon-components/scss/globals/scss/typography';
+@import '~carbon-components/scss/globals/scss/import-once';
+@import '~carbon-components/scss/globals/scss/css--reset';
+@import '~carbon-components/scss/globals/scss/css--typography';
 
 @include exports('cloud-modules') {
   .bx--module {

--- a/src/components/order-summary/_order-summary.scss
+++ b/src/components/order-summary/_order-summary.scss
@@ -1,7 +1,7 @@
-@import 'carbon-components/scss/globals/scss/colors';
-@import 'carbon-components/scss/globals/scss/theme';
-@import 'carbon-components/scss/globals/scss/mixins';
-@import 'carbon-components/scss/components/dropdown/dropdown';
+@import '~carbon-components/scss/globals/scss/colors';
+@import '~carbon-components/scss/globals/scss/theme';
+@import '~carbon-components/scss/globals/scss/mixins';
+@import '~carbon-components/scss/components/dropdown/dropdown';
 
 @include exports('cloud-order-summary') {
   .bx--order-summary {

--- a/src/components/resource-header/_resource-header.scss
+++ b/src/components/resource-header/_resource-header.scss
@@ -1,11 +1,11 @@
-@import 'carbon-components/scss/globals/scss/vars';
-@import 'carbon-components/scss/globals/scss/colors';
-@import 'carbon-components/scss/globals/scss/theme';
-@import 'carbon-components/scss/globals/scss/mixins';
-@import 'carbon-components/scss/globals/scss/typography';
-@import 'carbon-components/scss/globals/scss/spacing';
-@import 'carbon-components/scss/globals/scss/import-once';
-@import 'carbon-components/scss/globals/scss/css--typography';
+@import '~carbon-components/scss/globals/scss/vars';
+@import '~carbon-components/scss/globals/scss/colors';
+@import '~carbon-components/scss/globals/scss/theme';
+@import '~carbon-components/scss/globals/scss/mixins';
+@import '~carbon-components/scss/globals/scss/typography';
+@import '~carbon-components/scss/globals/scss/spacing';
+@import '~carbon-components/scss/globals/scss/import-once';
+@import '~carbon-components/scss/globals/scss/css--typography';
 
 @include exports('cloud-resource-header') {
   .#{$prefix}--resource-header {

--- a/src/components/tag-list/_tag-list.scss
+++ b/src/components/tag-list/_tag-list.scss
@@ -1,11 +1,11 @@
-@import 'carbon-components/scss/globals/scss/vars';
-@import 'carbon-components/scss/globals/scss/colors';
-@import 'carbon-components/scss/globals/scss/theme';
-@import 'carbon-components/scss/globals/scss/mixins';
-@import 'carbon-components/scss/globals/scss/typography';
-@import 'carbon-components/scss/globals/scss/spacing';
-@import 'carbon-components/scss/globals/scss/import-once';
-@import 'carbon-components/scss/globals/scss/css--typography';
+@import '~carbon-components/scss/globals/scss/vars';
+@import '~carbon-components/scss/globals/scss/colors';
+@import '~carbon-components/scss/globals/scss/theme';
+@import '~carbon-components/scss/globals/scss/mixins';
+@import '~carbon-components/scss/globals/scss/typography';
+@import '~carbon-components/scss/globals/scss/spacing';
+@import '~carbon-components/scss/globals/scss/import-once';
+@import '~carbon-components/scss/globals/scss/css--typography';
 @import '../tag/tag';
 
 @include exports('cloud-tag-list') {

--- a/src/components/tag/_tag.scss
+++ b/src/components/tag/_tag.scss
@@ -1,10 +1,10 @@
-@import 'carbon-components/scss/globals/scss/vars';
+@import '~carbon-components/scss/globals/scss/vars';
 @import 'colors';
-@import 'carbon-components/scss/globals/scss/theme';
-@import 'carbon-components/scss/globals/scss/spacing';
-@import 'carbon-components/scss/globals/scss/helper-mixins';
-@import 'carbon-components/scss/globals/scss/typography';
-@import 'carbon-components/scss/globals/scss/import-once';
+@import '~carbon-components/scss/globals/scss/theme';
+@import '~carbon-components/scss/globals/scss/spacing';
+@import '~carbon-components/scss/globals/scss/helper-mixins';
+@import '~carbon-components/scss/globals/scss/typography';
+@import '~carbon-components/scss/globals/scss/import-once';
 @import 'mixins';
 
 @include exports('cloud-tag') {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5531,6 +5531,12 @@ node-pre-gyp@^0.10.0:
     semver "^5.3.0"
     tar "^4"
 
+node-sass-tilde-importer@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/node-sass-tilde-importer/-/node-sass-tilde-importer-1.0.2.tgz#1a15105c153f648323b4347693fdb0f331bad1ce"
+  dependencies:
+    find-parent-dir "^0.3.0"
+
 node-sass@^4.8.3, node-sass@^4.9.0:
   version "4.9.0"
   resolved "https://registry.yarnpkg.com/node-sass/-/node-sass-4.9.0.tgz#d1b8aa855d98ed684d6848db929a20771cc2ae52"


### PR DESCRIPTION
This should solve #72, it certainly does solve it for me (tested locally in an Angular 6 project as linked package).

Feedback is needed however since this may break existing setup for other users.

#### Changelog
**New**
- **dependency**: `node-sass-tilde-import`

**Changed**
- relative stylesheet imports from peer `carbon-components` package by adding tilde `~` in import path
