### PR TITLE
fix(navbar): left nav bar title cropped when zoom

### DIFF
--- a/src/components/interior-left-nav/_interior-left-nav.scss
+++ b/src/components/interior-left-nav/_interior-left-nav.scss
@@ -196,7 +196,6 @@
     display: flex;
     flex-direction: column;
     width: rem(200px);
-    padding-top: rem(20px);
     transition: background-color 300ms $bx--standard-easing,
       width 300ms $bx--standard-easing;
 
@@ -227,8 +226,6 @@
     }
 
     .left-nav-list {
-      padding-top: 0;
-
       @include light-ui {
         background-color: inherit;
       }


### PR DESCRIPTION
Closes #
https://github.ibm.com/ibmcloud/account/issues/300

Fix the title to be cropped when increasing the zoom
#### Changelog

**Removed**

- Top padding that was creating the issue
