### PR TITLE
fix(tags): remove left margin in tags

### DIFF
--- a/src/components/tag/_tag.scss
+++ b/src/components/tag/_tag.scss
@@ -15,7 +15,7 @@
     align-items: center;
     padding: 0 rem(7px);
     height: 1.25rem;
-    margin: $spacing-3xs;
+    margin: $spacing-3xs $spacing-3xs $spacing-3xs 0;
     border-radius: rem(15px);
 
     &:not(:first-child) {


### PR DESCRIPTION
removes left margin from tags as per designer specs
![image](https://user-images.githubusercontent.com/2263351/51497607-3c3f0980-1d89-11e9-8f07-dc02b4d98567.png)
