### PR TITLE
feat: changed cursor pointer style when hovering over tag list

### DIFF
--- a/src/components/tag-list/_tag-list.scss
+++ b/src/components/tag-list/_tag-list.scss
@@ -12,6 +12,14 @@
   .#{$prefix}--tag-list {
     display: flex;
     align-items: center;
+
+    .#{$prefix}--tag--functional:hover {
+      cursor: pointer;
+    }
+
+    &:hover {
+      cursor: pointer;
+    }
   }
 
   .#{$prefix}--tag-list--tag {


### PR DESCRIPTION
Per Design request, would like the cursor to change to a hand when hovering the tag list to indicate to the user that tags are editable.

https://github.ibm.com/Bluemix/core-unified-console/issues/1276#event-42091810