### PR TITLE
fix(card): Update card colors so every status has one

### DIFF
--- a/src/components/card/_mixins.scss
+++ b/src/components/card/_mixins.scss
@@ -20,5 +20,13 @@
     &::before {
       background-color: $support-01;
     }
+  } @else if ($status == 'stopped') {
+    &::before {
+      background-color: $disabled-03;
+    }
+  } @else if ($status == 'limited') {
+    &::before {
+      background-color: $support-03;
+    }
   }
 }


### PR DESCRIPTION
Card statuses as defined [here](https://github.com/carbon-design-system/carbon-addons-cloud/blob/master/src/components/card/README.md) were not fully covered when determining the color of the status [here](https://github.com/carbon-design-system/carbon-addons-cloud/blob/master/src/components/card/_mixins.scss).

Updated _mixins.scss to assign colors to every status.

#### Changelog
**Changed**

- Added missing statuses `stopped` and `limited` to _mixins so their colors are not undefined
