### PR TITLE
fix(interior-left-nav): fixed nested list height limitation

### DIFF
--- a/src/components/interior-left-nav/_interior-left-nav.scss
+++ b/src/components/interior-left-nav/_interior-left-nav.scss
@@ -89,13 +89,12 @@
 
         &--expanded {
           .left-nav-list--nested {
-            max-height: 20rem;
-            transition: $transition--expansion $carbon--ease-in;
-            overflow: inherit;
-            opacity: 1;
+            max-height: 100%;
 
             .left-nav-list__item {
               opacity: 1;
+              height: auto;
+              max-height: 3rem;
             }
           }
 
@@ -123,17 +122,15 @@
     }
 
     .left-nav-list--nested {
-      max-height: 0;
-      overflow: hidden;
-      transition: $transition--expansion $carbon--ease-out;
       padding: 0;
-      opacity: 0;
 
       .left-nav-list__item {
         width: 100%;
+        height: auto;
+        max-height: 0;
         position: relative;
         padding: 0;
-        transition: $transition--base;
+        transition: $transition--expansion $carbon--ease-out;
         opacity: 0;
 
         &-link {


### PR DESCRIPTION
**Changed**

- instead of having an arbitrary height limit on the nested lists (which caused layout issues if you had more than 8 subitems) and animate the height of the whole list, I add the transition for the individual subitems so there is no upper limit on how many subitems you can have
- there is a small tradeoff with this solution though: now the items in a nested list has an upper limit on their height which is about 3 lines of text. I though it's a more reasonable limit than the previous
